### PR TITLE
remove throwing nades when finishing execute

### DIFF
--- a/scripting/executes/editor_menus.sp
+++ b/scripting/executes/editor_menus.sp
@@ -295,7 +295,6 @@ public int GiveNewExecuteMenuHandler(Menu menu, MenuAction action, int param1, i
     char choice[64];
     GetMenuItem(menu, param2, choice, sizeof(choice));
     if (StrEqual(choice, "finish")) {
-      ThrowEditingNades(float(freezetime), client, false);
       AddExecute(client);
       GiveNewExecuteMenu(client, pos);
 


### PR DESCRIPTION
First of all: Awesome plugin and great work you've done so far!

Back to the PR: When finishing an execute, the required nades are thrown automatically. That seems very odd to me. If that's by design, feel free to close the PR. Otherwise I've removed the responsible line to fix it.

P.S. Is it possible that you could activate the `Issues` tab?