### PR TITLE
Add preference menu for aug and sg

### DIFF
--- a/scripting/executes.sp
+++ b/scripting/executes.sp
@@ -748,7 +748,7 @@ public Action Event_PlayerSpawn(Event event, const char[] name, bool dontBroadca
   }
 
   if (!g_EditMode && InWarmup()) {
-    GivePrimaryRifle(client, GetClientTeam(client));
+    SetPrimaryRifle(client, GetClientTeam(client));
     GivePlayerItem(client, g_PlayerPrimary[client]);
     Client_SetArmor(client, 100);
     SetEntProp(client, Prop_Send, "m_bHasHelmet", true);
@@ -1098,7 +1098,7 @@ public void UpdateTeams() {
     if (IsValidClient(client)) {
       SwitchPlayerTeam(client, CS_TEAM_T);
       g_Team[client] = CS_TEAM_T;
-      GivePrimaryRifle(client, CS_TEAM_T);
+      SetPrimaryRifle(client, CS_TEAM_T);
       g_PlayerSecondary[client] = "weapon_glock";
       g_PlayerNades[client] = "";
       g_PlayerKit[client] = false;
@@ -1116,7 +1116,7 @@ public void UpdateTeams() {
       if (StrEqual(g_LastItemPickup[client], "ak47")) {
         g_PlayerPrimary[client] = "weapon_ak47";
       } else {
-        GivePrimaryRifle(client, CS_TEAM_CT);
+        SetPrimaryRifle(client, CS_TEAM_CT);
       }
 
       g_PlayerSecondary[client] = "weapon_hkp2000";

--- a/scripting/executes.sp
+++ b/scripting/executes.sp
@@ -188,9 +188,15 @@ bool g_AllowAWP[MAXPLAYERS + 1];
 Handle g_CZCTSideCookie;
 bool g_CZCTSide[MAXPLAYERS + 1];
 
+Handle g_SCOPECTSideCookie;
+bool g_SCOPECTSide[MAXPLAYERS + 1];
+
 // T
 Handle g_CZTSideCookie;
 bool g_CZTSide[MAXPLAYERS + 1];
+
+Handle g_SCOPETSideCookie;
+bool g_SCOPETSide[MAXPLAYERS + 1];
 
 SitePref g_SitePreference[MAXPLAYERS + 1];
 
@@ -341,6 +347,8 @@ public void OnPluginStart() {
   g_SilencedM4Cookie = RegClientCookie("executes_silencedm4", "", CookieAccess_Private);
   g_CZCTSideCookie = RegClientCookie("executes_cz_ct_side", "", CookieAccess_Private);
   g_CZTSideCookie = RegClientCookie("executes_cz_t_side", "", CookieAccess_Private);
+  g_SCOPECTSideCookie = RegClientCookie("executes_scope_ct_side", "", CookieAccess_Private);
+  g_SCOPETSideCookie = RegClientCookie("executes_scope_t_side", "", CookieAccess_Private);
 }
 
 public void OnPluginEnd() {

--- a/scripting/executes/loadout_common.sp
+++ b/scripting/executes/loadout_common.sp
@@ -42,7 +42,24 @@ public char RandomNade() {
   }
 }
 
-//
+public void GivePrimaryRifle(int client, int team) {
+  if (team == CS_TEAM_CT) {
+    if (g_CTRifle[client] == CTRiflePref_M4) {
+      g_PlayerPrimary[client] = "weapon_m4a1";
+    } else if (g_CTRifle[client] == CTRiflePref_Silenced_M4) {
+      g_PlayerPrimary[client] = "weapon_m4a1_silencer";
+    } else {
+      g_PlayerPrimary[client] = "weapon_aug";
+    }
+  } else {
+    if (g_TRifle[client] == TRiflePref_Ak) {
+      g_PlayerPrimary[client] = "weapon_ak47";
+    } else {
+      g_PlayerPrimary[client] = "weapon_sg556";
+    }
+  }
+}
+
 public void GiveUpgradedSecondary(int client, int team) {
   if (team == CS_TEAM_CT) {
     if (g_CZCTSide[client]) {

--- a/scripting/executes/loadout_common.sp
+++ b/scripting/executes/loadout_common.sp
@@ -42,7 +42,7 @@ public char RandomNade() {
   }
 }
 
-public void GivePrimaryRifle(int client, int team) {
+public void SetPrimaryRifle(int client, int team) {
   if (team == CS_TEAM_CT) {
     if (g_CTRifle[client] == CTRiflePref_M4) {
       g_PlayerPrimary[client] = "weapon_m4a1";

--- a/scripting/executes/loadout_forcerounds.sp
+++ b/scripting/executes/loadout_forcerounds.sp
@@ -83,8 +83,12 @@ static void AssignCT(int client) {
       }
     }
 
-    if (StrEqual(g_PlayerPrimary[client], "weapon_m4a1") && g_SilencedM4[client]) {
-      g_PlayerPrimary[client] = "weapon_m4a1_silencer";
+    if (StrEqual(g_PlayerPrimary[client], "weapon_m4a1")) {
+      if (g_CTRifle[client] == CTRiflePref_Silenced_M4) {
+        g_PlayerPrimary[client] = "weapon_m4a1_silencer";
+      } else if (g_CTRifle[client] == CTRiflePref_Aug) {
+        g_PlayerPrimary[client] = "weapon_aug";
+      }
     }
 
     if (StrEqual(g_LastItemPickup[client], "ak47")) {
@@ -163,5 +167,9 @@ static void AssignT(int client) {
     g_PlayerPrimary[client] = "";
     GiveUpgradedSecondary(client, CS_TEAM_T);
     g_PlayerNades[client] = "f";
+  }
+
+  if (StrEqual(g_PlayerPrimary[client], "weapon_ak47") && g_TRifle[client] == TRiflePref_Sg) {
+    g_PlayerPrimary[client] = "weapon_sg556";
   }
 }

--- a/scripting/executes/loadout_forcerounds.sp
+++ b/scripting/executes/loadout_forcerounds.sp
@@ -160,8 +160,4 @@ static void AssignT(int client) {
     GiveUpgradedSecondary(client, CS_TEAM_T);
     g_PlayerNades[client] = "f";
   }
-
-  if (StrEqual(g_PlayerPrimary[client], "weapon_ak47") && g_TRifle[client] == TRiflePref_Sg) {
-    g_PlayerPrimary[client] = "weapon_sg556";
-  }
 }

--- a/scripting/executes/loadout_forcerounds.sp
+++ b/scripting/executes/loadout_forcerounds.sp
@@ -34,7 +34,7 @@ static void AssignCT(int client) {
       AssignRandomNades(client, 2);
 
     } else if (f < 0.4) {
-      GivePrimaryRifle(client, CS_TEAM_CT);
+      SetPrimaryRifle(client, CS_TEAM_CT);
       AssignRandomNades(client, 0);
 
     } else if (f < 0.5) {
@@ -136,10 +136,10 @@ static void AssignCTNades(int client, int spawn) {
 static void AssignT(int client) {
   float f = GetRandomFloat();
   if (f < 0.1) {
-    GivePrimaryRifle(client, CS_TEAM_T);
+    SetPrimaryRifle(client, CS_TEAM_T);
     g_PlayerNades[client] = "f";
   } else if (f < 0.3) {
-    GivePrimaryRifle(client, CS_TEAM_T);
+    SetPrimaryRifle(client, CS_TEAM_T);
     g_PlayerNades[client] = "";
 
   } else if (f < 0.35) {

--- a/scripting/executes/loadout_forcerounds.sp
+++ b/scripting/executes/loadout_forcerounds.sp
@@ -34,7 +34,7 @@ static void AssignCT(int client) {
       AssignRandomNades(client, 2);
 
     } else if (f < 0.4) {
-      g_PlayerPrimary[client] = "weapon_m4a1";
+      GivePrimaryRifle(client, CS_TEAM_CT);
       AssignRandomNades(client, 0);
 
     } else if (f < 0.5) {
@@ -80,14 +80,6 @@ static void AssignCT(int client) {
       g_PlayerPrimary[client] = "weapon_mag7";
       if (Chance(0.1)) {
         g_PlayerPrimary[client] = "weapon_p90";
-      }
-    }
-
-    if (StrEqual(g_PlayerPrimary[client], "weapon_m4a1")) {
-      if (g_CTRifle[client] == CTRiflePref_Silenced_M4) {
-        g_PlayerPrimary[client] = "weapon_m4a1_silencer";
-      } else if (g_CTRifle[client] == CTRiflePref_Aug) {
-        g_PlayerPrimary[client] = "weapon_aug";
       }
     }
 
@@ -144,10 +136,10 @@ static void AssignCTNades(int client, int spawn) {
 static void AssignT(int client) {
   float f = GetRandomFloat();
   if (f < 0.1) {
-    g_PlayerPrimary[client] = "weapon_ak47";
+    GivePrimaryRifle(client, CS_TEAM_T);
     g_PlayerNades[client] = "f";
   } else if (f < 0.3) {
-    g_PlayerPrimary[client] = "weapon_ak47";
+    GivePrimaryRifle(client, CS_TEAM_T);
     g_PlayerNades[client] = "";
 
   } else if (f < 0.35) {

--- a/scripting/executes/loadout_gunrounds.sp
+++ b/scripting/executes/loadout_gunrounds.sp
@@ -40,9 +40,7 @@ static void AssignCT(int client, bool helpCT) {
     }
 
   } else {
-    if (g_SCOPECTSide[client] && Chance(0.25)) {
-      g_PlayerPrimary[client] = "weapon_aug";
-    } else if (Chance(0.02)) {
+    if (Chance(0.02)) {
       g_PlayerPrimary[client] = "weapon_famas";
     } else if (Chance(0.0005)) {
       g_PlayerPrimary[client] = "weapon_negev";
@@ -143,9 +141,7 @@ static void AssignT(int client, bool hurtT) {
     }
 
   } else {
-    if (g_SCOPETSide[client] && Chance(0.25)) {
-      g_PlayerPrimary[client] = "weapon_sg556";
-    } else if (Chance(0.02)) {
+    if (Chance(0.02)) {
       g_PlayerPrimary[client] = "weapon_galilar";
     } else if (Chance(0.002)) {
       g_PlayerPrimary[client] = "weapon_m249";

--- a/scripting/executes/loadout_gunrounds.sp
+++ b/scripting/executes/loadout_gunrounds.sp
@@ -40,10 +40,10 @@ static void AssignCT(int client, bool helpCT) {
     }
 
   } else {
-    if (Chance(0.02)) {
-      g_PlayerPrimary[client] = "weapon_famas";
-    } else if (Chance(0.002)) {
+    if (g_SCOPECTSide[client] && Chance(0.25)) {
       g_PlayerPrimary[client] = "weapon_aug";
+    } else if (Chance(0.02)) {
+      g_PlayerPrimary[client] = "weapon_famas";
     } else if (Chance(0.0005)) {
       g_PlayerPrimary[client] = "weapon_negev";
     } else if (Chance(0.0005)) {
@@ -143,10 +143,10 @@ static void AssignT(int client, bool hurtT) {
     }
 
   } else {
-    if (Chance(0.02)) {
-      g_PlayerPrimary[client] = "weapon_galilar";
-    } else if (Chance(0.002)) {
+    if (g_SCOPETSide[client] && Chance(0.25)) {
       g_PlayerPrimary[client] = "weapon_sg556";
+    } else if (Chance(0.02)) {
+      g_PlayerPrimary[client] = "weapon_galilar";
     } else if (Chance(0.002)) {
       g_PlayerPrimary[client] = "weapon_m249";
     }

--- a/scripting/executes/prefs_menu.sp
+++ b/scripting/executes/prefs_menu.sp
@@ -158,9 +158,9 @@ public TRiflePref GetTRiflePrefCookie(int client) {
 }
 
 public void SetCTRiflePrefCookie(int client, CTRiflePref pref) {
-  SetCookieIntByName(client, "executes_ct_rifle", view_as<int>(pref));
+  SetCookieInt(client, g_CTRiflePrefCookie, view_as<int>(pref));
 }
 
 public void SetTRiflePrefCookie(int client, TRiflePref pref) {
-  SetCookieIntByName(client, "executes_t_rifle", view_as<int>(pref));
+  SetCookieInt(client, g_TRiflePrefCookie, view_as<int>(pref));
 }

--- a/scripting/executes/prefs_menu.sp
+++ b/scripting/executes/prefs_menu.sp
@@ -40,6 +40,18 @@ public void GivePreferencesMenu(int client) {
   }
   menu.AddItem("cz_t", buffer);
 
+  buffer = "Allow receiving Augs: no";
+  if (g_SCOPECTSide[client]) {
+    buffer = "Allow receiving Augs: yes";
+  }
+  menu.AddItem("scope_ct", buffer);
+
+  buffer = "Allow receiving SG 553: no";
+  if (g_SCOPETSide[client]) {
+    buffer = "Allow receiving SG 553: yes";
+  }
+  menu.AddItem("scope_t", buffer);
+
   menu.Display(client, 15);
 }
 
@@ -82,6 +94,16 @@ public int PreferencesMenuHandler(Menu menu, MenuAction action, int param1, int 
       SetCookieBool(client, g_CZTSideCookie, g_CZTSide[client]);
       GivePreferencesMenu(client);
 
+    } else if (StrEqual(choice, "scope_ct")) {
+      g_SCOPECTSide[client] = !g_SCOPECTSide[client];
+      SetCookieBool(client, g_SCOPECTSideCookie, g_SCOPECTSide[client]);
+      GivePreferencesMenu(client);
+
+    } else if (StrEqual(choice, "scope_t")) {
+      g_SCOPETSide[client] = !g_SCOPETSide[client];
+      SetCookieBool(client, g_SCOPETSideCookie, g_SCOPETSide[client]);
+      GivePreferencesMenu(client);
+
     } else {
       LogError("unknown pref string = %s", choice);
     }
@@ -100,6 +122,8 @@ public void OnClientCookiesCached(int client) {
   g_SitePreference[client] = GetSitePrefCookie(client);
   g_CZCTSide[client] = GetCookieBool(client, g_CZCTSideCookie, true);
   g_CZTSide[client] = GetCookieBool(client, g_CZTSideCookie, true);
+  g_SCOPECTSide[client] = GetCookieBool(client, g_SCOPECTSideCookie, true);
+  g_SCOPETSide[client] = GetCookieBool(client, g_SCOPETSideCookie, true);
 }
 
 public void SetSitePrefCookie(int client, SitePref site) {

--- a/scripting/include/executes.inc
+++ b/scripting/include/executes.inc
@@ -27,6 +27,17 @@ enum StratType {
   StratType_ForceBuy = 2,
 };
 
+enum CTRiflePref {
+  CTRiflePref_M4 = 0,
+  CTRiflePref_Silenced_M4 = 1,
+  CTRiflePref_Aug = 2,
+}
+
+enum TRiflePref {
+  TRiflePref_Ak = 0,
+  TRiflePref_Sg = 1,
+}
+
 // Most spawn flags only apply to gun rounds typically.
 #define SPAWNFLAG_MOLOTOV (1 << 0)
 #define SPAWNFLAG_MAG7 (1 << 1)     // CT only

--- a/scripting/include/executes.inc
+++ b/scripting/include/executes.inc
@@ -27,17 +27,6 @@ enum StratType {
   StratType_ForceBuy = 2,
 };
 
-enum CTRiflePref {
-  CTRiflePref_M4 = 0,
-  CTRiflePref_Silenced_M4 = 1,
-  CTRiflePref_Aug = 2,
-}
-
-enum TRiflePref {
-  TRiflePref_Ak = 0,
-  TRiflePref_Sg = 1,
-}
-
 // Most spawn flags only apply to gun rounds typically.
 #define SPAWNFLAG_MOLOTOV (1 << 0)
 #define SPAWNFLAG_MAG7 (1 << 1)     // CT only


### PR DESCRIPTION
Implements the feature for issue #25.

This makes it so that players can opt in to receiving scoped rifles on CT & T side. If they opt in, then there is a 25% chance that they will receive an sg/aug instead of an m4/ak. I'm not married to this percentage at all if you have any feedback on how to better incorporate this feature.
