### PR TITLE
silence join event and reduce warmup end time.

### DIFF
--- a/scripting/executes.sp
+++ b/scripting/executes.sp
@@ -654,7 +654,7 @@ public void EndWarmup() {
                         g_hMinPlayers.IntValue);
   ServerCommand("mp_death_drop_gun 1");
   ServerCommand("mp_warmup_pausetimer 0");
-  ServerCommand("mp_warmuptime 3");
+  ServerCommand("mp_warmuptime 5");
 }
 
 public Action Command_Drop(int client, const char[] command, int argc) {

--- a/scripting/executes.sp
+++ b/scripting/executes.sp
@@ -654,7 +654,7 @@ public void EndWarmup() {
                         g_hMinPlayers.IntValue);
   ServerCommand("mp_death_drop_gun 1");
   ServerCommand("mp_warmup_pausetimer 0");
-  ServerCommand("mp_warmuptime 10");
+  ServerCommand("mp_warmuptime 3");
 }
 
 public Action Command_Drop(int client, const char[] command, int argc) {
@@ -690,7 +690,7 @@ public Action Event_PlayerTeam(Event event, const char[] name, bool dontBroadcas
     return Plugin_Continue;
   }
 
-  SetEventBroadcast(event, true);
+  SetEventBool(event, "silent", true);
   return Plugin_Continue;
 }
 


### PR DESCRIPTION
warmup restarts multiple times when map changes with multiple people in it. 
this somehow fixes it (i swear i forgot the reasoning how it works) but it works. 